### PR TITLE
Expose modules at package level

### DIFF
--- a/src/dapy/__init__.py
+++ b/src/dapy/__init__.py
@@ -16,10 +16,8 @@ Using this library consists of two main steps:
 2. Simulating the algorithm using the simulation framework.
 """
 
-# Import submodules to make them accessible as dapy.core, dapy.algo, dapy.sim
 from . import core
 from . import algo
 from . import sim
 
-# Make submodules available at package level
 __all__ = ['core', 'algo', 'sim']

--- a/src/dapy/__init__.py
+++ b/src/dapy/__init__.py
@@ -15,3 +15,11 @@ Using this library consists of two main steps:
 1. Defining a distributed algorithm using the core components.
 2. Simulating the algorithm using the simulation framework.
 """
+
+# Import submodules to make them accessible as dapy.core, dapy.algo, dapy.sim
+from . import core
+from . import algo
+from . import sim
+
+# Make submodules available at package level
+__all__ = ['core', 'algo', 'sim']


### PR DESCRIPTION
## Problem
```
uv run python
Python 3.13.2 (main, Mar 17 2025, 21:02:54) [Clang 20.1.0 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import dapy
>>> dapy.core
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    dapy.core
AttributeError: module 'dapy' has no attribute 'core'
>>> import dapy.core
```
It is a bit tricky for me.
## Solusion
Modified `__init__.py`
```
❯ uv run python                                               
Python 3.13.2 (main, Mar 17 2025, 21:02:54) [Clang 20.1.0 ] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import dapy
>>> dapy.core
<module 'dapy.core' from '/home/saiten/distributed-algorithm/dapy/src/dapy/core/__init__.py'>
>>> import dapy.core
```

P.S. It might be what I am expecting is wrong, thus feel free to close this PR. 
